### PR TITLE
Destroy falcon environments on PR close

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -32,6 +32,19 @@ class Bot {
     })
   }
 
+  getFalconComponentName(skinName) {
+    // normalize cresus name
+    if (skinName === 'cresuscasino') {
+      skinName = 'cresus';
+    }
+
+    return `xcaf-${skinName}`;
+  }
+
+  getFalconName(componentName, ref) {
+    return `${componentName}-${ref.substr(0, 40).toLocaleLowerCase()}`;
+  }
+
   getFalconComponent(deploy = false, image = null, tag = null, branch = null, type, config = {}) {
     return {
       deploy,
@@ -45,15 +58,9 @@ class Bot {
 
   falconDeploy(pr, skinInfo) {
     const expirationTime = 2592000;
-    let skin = skinInfo.skinName;
 
-    // normalize cresus name
-    if (skin === 'cresuscasino') {
-      skin = 'cresus';
-    }
-
-    const componentName = `xcaf-${skin}`;
-    const slug = `${skin}-${pr.head.ref.substr(0, 40).toLocaleLowerCase()}`;
+    const componentName = this.getFalconComponentName(skinInfo.skinName);
+    const slug = this.getFalconName(componentName, pr.head.ref);
 
     const payload = {
       fullOwner: pr.head.user.login,
@@ -91,7 +98,21 @@ class Bot {
         'skin_xcaf',
       );
 
-    this.websocket.emit('falcon:create',{ url: config.falconUrl, payload });
+    this.websocket.emit('falcon:create', { url: config.falconUrl, payload });
+
+    return {
+      skin,
+      link: this.getLink(componentName, slug),
+      payload
+    };
+  }
+
+  falconDestroy(pr, skinInfo) {
+    const componentName = this.getFalconComponentName(skinInfo.skinName);
+    const slug = this.getFalconName(componentName, pr.head.ref);
+    const payload = { slug };
+
+    this.websocket.emit('falcon:destroy', { url: config.falconUrl, payload });
 
     return {
       skin,

--- a/src/routes/pullrequest.js
+++ b/src/routes/pullrequest.js
@@ -67,6 +67,8 @@ router.post('/', function (req, res) {
         res.json({ status: 'Closing' });
         if (pr.merged_at) Bot.getIssues(pr, issues => Bot.websocket.emit('merged', { issues }));
         Bot.websocket.emit('screenshot:purge', { branch: pr.head.ref });
+        // Loop through each skin and tell Falcon to destroy the environment
+        config.projects.forEach((skin) => Bot.falconDestroy(pr, config.projectsInfo[skin]));
         break;
       default:
         res.json({ status: 'Default, no action' });
@@ -90,6 +92,8 @@ router.get('/close/:id', function (req, res) {
   Bot.getPullRequest(req.params.id, pr => {
     res.json({ status: 'Doing initial setup on ' + pr.title });
     Bot.closeClone(pr, 'CRES');
+    // Loop through each skin and tell Falcon to destroy the environment
+    config.projects.forEach((skin) => Bot.falconDestroy(pr, config.projectsInfo[skin]));
   });
 });
 


### PR DESCRIPTION
Hopefully this is correct. I was a little confused to see there's two places that handle deploying to Falcon, so just put the destroy logic into two places as well.

I think that could be refactored so there's only 1 of each?

```ts
router.post('/', function (req, res) {
```
and 
```ts
router.get('/close/:id', function (req, res) {
```